### PR TITLE
allow user to quit with 'q'

### DIFF
--- a/bagels_with_words.py
+++ b/bagels_with_words.py
@@ -6,6 +6,7 @@ class BagelsWithWords:
     Based on Bagels, by Al Sweigart. Inspired by Wordle. Powered by Wordnik.
     Tags: short, game, puzzle
     """
+
     def __init__(self, word_length, max_guesses):
         self.word_length = word_length
         self.max_guesses = max_guesses
@@ -65,6 +66,7 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
         '&minDictionaryCount=20&maxDictionaryCount=-1' \
         f'&minLength={self.word_length}&maxLength={self.word_length}' \
         f'&api_key={self.api_key}'
+
         while True:
             r = requests.get(url)
             if r.status_code == 200:
@@ -77,6 +79,7 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
         Ask user for guesses. Enumerates guesses.
         Compare guesses to secret word.
         """
+
         num_guesses = 1
         while num_guesses <= self.max_guesses:
             guess = ''
@@ -120,6 +123,7 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
         'limit=200&includeRelated=false&' \
         'sourceDictionaries=ahd-5%2Ccentury%2Cwiktionary%2Cwebster%2Cwordnet&' \
         f'useCanonical=false&includeTags=false&api_key={self.api_key}'
+
         while True:
             r = requests.get(url)
             if r.status_code == 200:
@@ -130,6 +134,7 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
     def _get_frequency(self, word):
         """Take a word and return a dictionary with letters as the key and
         their frequency as the value."""
+
         freq = {}
         for keys in word:
             freq[keys] = freq.get(keys, 0) + 1

--- a/bagels_with_words.py
+++ b/bagels_with_words.py
@@ -24,15 +24,17 @@ class BagelsWithWords:
             secret_word = self.get_secret_word()
             print('\nI have thought up a word.')
             print(f'You have {self.max_guesses} guesses to get.\n')
+            print('Press \'Q\' at any time to quit.\n')
             # Initiate loop for guesses.
             self.guess_loop(secret_word)
             # Ask the player if they want to play again.
-            print('Do you want to play again? (yes or no)')
-            if not input('> ').lower().startswith('y'):
+            if not input('Do you want to play again? (y/n): ').lower(
+            ).startswith('y'):
                 break
         print('Thanks for playing!')
 
     def intro(self):
+
         print(f'''\nBagels with Words, a deductive logic game.
 
 Based on Bagels, by Al Sweigart. Inspired by Wordle. Powered by Wordnik.
@@ -77,18 +79,33 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
         Ask user for guesses. Enumerates guesses.
         Compare guesses to secret word.
         """
+
         num_guesses = 1
+        quit_flag = False
         while num_guesses <= self.max_guesses:
             guess = ''
             # Keep looping until they enter a valid guess:
             while len(guess) != self.word_length or not check:
                 print(f'Guess #{num_guesses}: ')
                 guess = input('> ').lower()
+
+                if guess.lower() == 'q':
+                    confirm = input('Are you sure you want to quit? (y/n): ')
+                    if confirm.lower().startswith('y'):
+                        print('Well, you tried.')
+                        quit_flag = 'True'
+                        break  # user wants to quit, so get them out
+                    else:
+                        continue
+
                 check = self._check_if_guess_exists(guess)
                 if len(guess) != self.word_length:
                     print(f"Remember: {self.word_length}-letter word.")
                 elif not check:
                     print("I don't recognize this word.")
+
+            if quit_flag:
+                break
 
             if guess == secret_word:
                 print(f"You got it in {num_guesses} guesses!")

--- a/bagels_with_words.py
+++ b/bagels_with_words.py
@@ -1,4 +1,4 @@
-import requests, json
+import requests, json, sys
 
 class BagelsWithWords:
     """
@@ -24,7 +24,7 @@ class BagelsWithWords:
             secret_word = self.get_secret_word()
             print('\nI have thought up a word.')
             print(f'You have {self.max_guesses} guesses to get.\n')
-            print('Press \'Q\' at any time to quit.\n')
+            print('Enter \'q\' at any time to quit.\n')
             # Initiate loop for guesses.
             self.guess_loop(secret_word)
             # Ask the player if they want to play again.
@@ -34,7 +34,6 @@ class BagelsWithWords:
         print('Thanks for playing!')
 
     def intro(self):
-
         print(f'''\nBagels with Words, a deductive logic game.
 
 Based on Bagels, by Al Sweigart. Inspired by Wordle. Powered by Wordnik.
@@ -66,7 +65,6 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
         '&minDictionaryCount=20&maxDictionaryCount=-1' \
         f'&minLength={self.word_length}&maxLength={self.word_length}' \
         f'&api_key={self.api_key}'
-
         while True:
             r = requests.get(url)
             if r.status_code == 200:
@@ -79,9 +77,7 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
         Ask user for guesses. Enumerates guesses.
         Compare guesses to secret word.
         """
-
         num_guesses = 1
-        quit_flag = False
         while num_guesses <= self.max_guesses:
             guess = ''
             # Keep looping until they enter a valid guess:
@@ -92,9 +88,8 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
                 if guess.lower() == 'q':
                     confirm = input('Are you sure you want to quit? (y/n): ')
                     if confirm.lower().startswith('y'):
-                        print('Well, you tried.')
-                        quit_flag = 'True'
-                        break  # user wants to quit, so get them out
+                        print('Thanks for playing!')
+                        sys.exit()
                     else:
                         continue
 
@@ -103,9 +98,6 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
                     print(f"Remember: {self.word_length}-letter word.")
                 elif not check:
                     print("I don't recognize this word.")
-
-            if quit_flag:
-                break
 
             if guess == secret_word:
                 print(f"You got it in {num_guesses} guesses!")
@@ -128,7 +120,6 @@ the clues would be "Fermi Pico Bruno Bruno Bruno".''')
         'limit=200&includeRelated=false&' \
         'sourceDictionaries=ahd-5%2Ccentury%2Cwiktionary%2Cwebster%2Cwordnet&' \
         f'useCanonical=false&includeTags=false&api_key={self.api_key}'
-
         while True:
             r = requests.get(url)
             if r.status_code == 200:


### PR DESCRIPTION
Updated guess_loop function to allow user to quit at any time by entering 'q'. Feels more elegant than Ctrl-C, and lets you continue playing, with a new word, without quitting the program.